### PR TITLE
DPI-2930 Package rhtmlTemplate in nix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Version: 1.0.0
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: An opinionated template for the creation of html widget repositories using ES6
+Imports: htmlwidgets
 License: GPL-3
 LazyData: TRUE
 RoxygenNote: 7.1.1

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlTemplate";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''An opinionated template for the creation of html widget repositories using ES6'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlTemplate in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR